### PR TITLE
Linux x86 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 # Compiler options
 CC=gcc
 #CC=i686-w64-mingw32-gcc
-BASE_CFLAGS=-Dstricmp=strcasecmp -DC_ONLY
+BASE_CFLAGS=-Dstricmp=strcasecmp -DC_ONLY -m32
 
 #use these cflags to optimize it
 CFLAGS=$(BASE_CFLAGS) -O6 -ffast-math -funroll-loops \

--- a/src/bl_main.c
+++ b/src/bl_main.c
@@ -825,6 +825,7 @@ void BotLibImport_FreeMemory(void *ptr)
 // Returns:					-
 // Changes Globals:		-
 //===========================================================================
+__attribute__((callee_pop_aggregate_return(0)))
 bsp_trace_t BotLibImport_Trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int passent, int contentmask)
 {
 	bsp_trace_t bsptrace;


### PR DESCRIPTION
I needed these fixes in addition to the fine work you've already done to get past a segfault due to a corrupted stack immediately after loading the AAS data, and to force building a 32-bit library on my 64-bit multilib gentoo install.  Let me know if you have any questions or feedback on the patches.  I'm a little worried I'm missing something on the function ABI attribute one, because it seems like this should currently be broken for everyone on Linux if the fix is right.